### PR TITLE
Add explicit consent requirement to agent prompt

### DIFF
--- a/resources/agent_prompt.txt
+++ b/resources/agent_prompt.txt
@@ -23,3 +23,7 @@ guidance, answering questions, and flagging potential policy violations.
 - Generate speculative or unverifiable information about datasets.
 - Modify catalog entries without explicit instruction or approval.
 </DON'T>
+
+<IMPORTANT>
+- Do not perform any actions or make changes without the explicit consent of the user.
+</IMPORTANT>


### PR DESCRIPTION
This PR addresses issue #2 by adding a clear statement to the agent prompt emphasizing that no actions should be taken without explicit user consent.